### PR TITLE
history size configable and ignore cmd in history feautre

### DIFF
--- a/src/main/java/io/termd/core/spi/ConfigProvider.java
+++ b/src/main/java/io/termd/core/spi/ConfigProvider.java
@@ -1,0 +1,12 @@
+package io.termd.core.spi;
+
+import java.util.regex.Pattern;
+
+public interface ConfigProvider {
+
+  public String get(String p, String defaultVal);
+
+  public int getHistoryMaxSize();
+
+  public Pattern getHistoryIgnorePattern();
+}

--- a/src/main/java/io/termd/core/spi/impl/ConfigProvider4default.java
+++ b/src/main/java/io/termd/core/spi/impl/ConfigProvider4default.java
@@ -1,0 +1,36 @@
+package io.termd.core.spi.impl;
+
+import java.util.regex.Pattern;
+import io.termd.core.spi.ConfigProvider;
+
+public final class ConfigProvider4default implements ConfigProvider {
+
+  private final int historyMaxSize;
+  private final Pattern historyIgnorePattern;
+
+  public ConfigProvider4default() {
+    super();
+    historyMaxSize = Integer.getInteger("termd_max_history_size", 500);
+    String tmp = get("termd_history_ignore_pattern", null);// "\\s*history"
+    if (tmp == null || tmp.isEmpty()) {
+      historyIgnorePattern = null;
+    } else {
+      historyIgnorePattern = Pattern.compile(tmp);
+    }
+  }
+
+  @Override
+  public String get(String p, String defaultVal) {
+    return System.getProperty(p, defaultVal);
+  }
+
+  @Override
+  public int getHistoryMaxSize() {
+    return historyMaxSize;
+  }
+
+  @Override
+  public Pattern getHistoryIgnorePattern() {
+    return historyIgnorePattern;
+  }
+}

--- a/src/main/resources/META-INF/services/io.termd.core.spi.ConfigProvider
+++ b/src/main/resources/META-INF/services/io.termd.core.spi.ConfigProvider
@@ -1,0 +1,1 @@
+io.termd.core.spi.impl.ConfigProvider4default


### PR DESCRIPTION
可修历史记录大小及对将某些指令使用正则表达来排除到历史记录之外：如history命令
需要设置系统属性后生效，如：
```
-Dtermd_max_history_size=500
-Dtermd_history_ignore_pattern=^\\s*history
```

配置termd_history_ignore_pattern的用意是在历史记录中人为排除一些无有价值命令
