### PR TITLE
去除pom.xml中重复定义的maven-resources-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -299,12 +299,6 @@
                 <encoding>UTF-8</encoding>
             </configuration>
         </plugin>
-        <plugin>
-            <artifactId>maven-resources-plugin</artifactId>
-            <configuration>
-                <encoding>UTF-8</encoding>
-            </configuration>
-        </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
'build.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.apache.maven.plugins:maven-resources-plugin @ line 302, column 17