### PR TITLE
TtyWebSocketFrameHandler support removing specify handler class after protocol upgrade

### DIFF
--- a/src/main/java/io/termd/core/http/netty/TtyServerInitializer.java
+++ b/src/main/java/io/termd/core/http/netty/TtyServerInitializer.java
@@ -62,6 +62,6 @@ public class TtyServerInitializer extends ChannelInitializer<SocketChannel> {
 
     pipeline.addLast(httpRequestHandler);
     pipeline.addLast(new WebSocketServerProtocolHandler("/ws"));
-    pipeline.addLast(new TtyWebSocketFrameHandler(group, handler));
+    pipeline.addLast(new TtyWebSocketFrameHandler(group, handler, HttpRequestHandler.class));
   }
 }

--- a/src/main/java/io/termd/core/http/netty/TtyWebSocketFrameHandler.java
+++ b/src/main/java/io/termd/core/http/netty/TtyWebSocketFrameHandler.java
@@ -38,9 +38,16 @@ public class TtyWebSocketFrameHandler extends SimpleChannelInboundHandler<TextWe
   private final Consumer<TtyConnection> handler;
   private ChannelHandlerContext context;
   private HttpTtyConnection conn;
-  private Class[] removingHandlerClasses;
+  private Class removingHandlerClasses;
 
-  public TtyWebSocketFrameHandler(ChannelGroup group, Consumer<TtyConnection> handler, Class... removingHandlerClasses) {
+  /**
+   * Create TtyWebSocketFrameHandler
+   *
+   * @param group
+   * @param handler tty connection handler
+   * @param removingHandlerClasses  removing handler classes after protocol upgrade
+   */
+  public TtyWebSocketFrameHandler(ChannelGroup group, Consumer<TtyConnection> handler, Class removingHandlerClasses) {
     this.group = group;
     this.handler = handler;
     this.removingHandlerClasses = removingHandlerClasses;
@@ -56,9 +63,7 @@ public class TtyWebSocketFrameHandler extends SimpleChannelInboundHandler<TextWe
   public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
     if (evt == WebSocketServerProtocolHandler.ServerHandshakeStateEvent.HANDSHAKE_COMPLETE) {
       if (removingHandlerClasses != null) {
-        for (Class handlerClass : removingHandlerClasses) {
-          ctx.pipeline().remove(handlerClass);
-        }
+        ctx.pipeline().remove(removingHandlerClasses);
       }
       group.add(ctx.channel());
       conn = new HttpTtyConnection() {

--- a/src/main/java/io/termd/core/http/netty/TtyWebSocketFrameHandler.java
+++ b/src/main/java/io/termd/core/http/netty/TtyWebSocketFrameHandler.java
@@ -38,19 +38,19 @@ public class TtyWebSocketFrameHandler extends SimpleChannelInboundHandler<TextWe
   private final Consumer<TtyConnection> handler;
   private ChannelHandlerContext context;
   private HttpTtyConnection conn;
-  private Class removingHandlerClasses;
+  private Class removingHandlerClass;
 
   /**
    * Create TtyWebSocketFrameHandler
    *
    * @param group
    * @param handler tty connection handler
-   * @param removingHandlerClasses  removing handler classes after protocol upgrade
+   * @param removingHandlerClass  removing specify handler class after protocol upgrade
    */
-  public TtyWebSocketFrameHandler(ChannelGroup group, Consumer<TtyConnection> handler, Class removingHandlerClasses) {
+  public TtyWebSocketFrameHandler(ChannelGroup group, Consumer<TtyConnection> handler, Class removingHandlerClass) {
     this.group = group;
     this.handler = handler;
-    this.removingHandlerClasses = removingHandlerClasses;
+    this.removingHandlerClass = removingHandlerClass;
   }
 
   @Override
@@ -62,8 +62,8 @@ public class TtyWebSocketFrameHandler extends SimpleChannelInboundHandler<TextWe
   @Override
   public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
     if (evt == WebSocketServerProtocolHandler.ServerHandshakeStateEvent.HANDSHAKE_COMPLETE) {
-      if (removingHandlerClasses != null) {
-        ctx.pipeline().remove(removingHandlerClasses);
+      if (removingHandlerClass != null) {
+        ctx.pipeline().remove(removingHandlerClass);
       }
       group.add(ctx.channel());
       conn = new HttpTtyConnection() {


### PR DESCRIPTION
add parameter 'removingHandlerClasses' to TtyWebSocketFrameHandler, removing specify handler class after protocol upgrade, resolve compatibility with arthas.